### PR TITLE
Fix migration container drop

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -11,20 +11,25 @@ services:
       ./postgres.env
     networks:
       - app-network
-    
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -h localhost -p 5432"]
+      interval: 10s
+      retries: 5
+      start_period: 1s
+      timeout: 5s
   migrations:
-    build: 
+    build:
       context: .
       dockerfile: migrations.Dockerfile
-    command: "alembic upgrade head"
+    command: ["sh", "-c", "until pg_isready -U postgres -h postgres -p 5432; do echo Waiting for DB; sleep 2; done; alembic upgrade head"]
     volumes:
       - ./migration:/code/migration
       - ./core:/code/core
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     networks:
       - app-network
-  
   auth-service:
     build: ./auth-service
     command: "uvicorn app.main:app --reload --workers 1 --host 0.0.0.0 --port 8000"

--- a/migrations.Dockerfile
+++ b/migrations.Dockerfile
@@ -1,8 +1,8 @@
 
-FROM python:3.12-slim
+FROM python:3.12-alpine
 
 WORKDIR /code
-
+RUN apk add --no-cache gcc musl-dev libffi-dev postgresql-client
 COPY requirements.txt /code/requirements.txt
 
 RUN pip install --upgrade pip


### PR DESCRIPTION
Fix migration container drop because of starting container before postgres container was started. Add healthcheck for PgDb